### PR TITLE
Fix chrome backspace bug in newline

### DIFF
--- a/jquery.rich_textarea.js
+++ b/jquery.rich_textarea.js
@@ -3681,7 +3681,7 @@ if ( typeof( ddt ) == 'undefined' )
 
 						var textnode = this._insertEmptyNode( dom_node, 'before' );
 
-						this._setCaretPositionRelative( textnode, 'end' );
+						this._setCaretPositionRelative( textnode, 'before' );
 
 						return;
 						}


### PR DESCRIPTION
now able to go one line up with backspace at the beginning of a new line

still buggy. double enter need three backspace to revert to old state
